### PR TITLE
Factorise the common parts in keystore implementations

### DIFF
--- a/pkg/keystore/memory.go
+++ b/pkg/keystore/memory.go
@@ -62,7 +62,6 @@ func (s *InMemoryKeystore) Reset(id uuid.UUID) error {
 func (s *InMemoryKeystore) Create(
 	extendedPublicKey string, fromChainCode *FromChainCode, scheme Scheme, net chaincfg.Network, lookaheadSize uint32,
 ) (KeychainInfo, error) {
-
 	meta, err := keystoreCreate(
 		extendedPublicKey,
 		fromChainCode,
@@ -98,7 +97,7 @@ func (s InMemoryKeystore) GetFreshAddresses(
 	if !ok {
 		return addrs, ErrKeychainNotFound
 	}
-	addrs, err := meta.keystoreGetFreshAddresses(s.client, id, change, size)
+	addrs, err := meta.keystoreGetFreshAddresses(s.client, change, size)
 	if err != nil {
 		return addrs, err
 	}
@@ -129,7 +128,7 @@ func (s *InMemoryKeystore) GetAllObservableAddresses(
 		return nil, ErrKeychainNotFound
 	}
 	return meta.keystoreGetAllObservableAddresses(
-		s.client, id, change, fromIndex, toIndex,
+		s.client, change, fromIndex, toIndex,
 	)
 }
 

--- a/pkg/keystore/memory.go
+++ b/pkg/keystore/memory.go
@@ -4,7 +4,6 @@ import (
 	"github.com/google/uuid"
 	"github.com/ledgerhq/bitcoin-keychain/pb/bitcoin"
 	"github.com/ledgerhq/bitcoin-keychain/pkg/chaincfg"
-	"github.com/pkg/errors"
 )
 
 // InMemoryKeystore implements the Keystore interface where the storage
@@ -17,6 +16,9 @@ type InMemoryKeystore struct {
 	client bitcoin.CoinServiceClient
 }
 
+// Schema is a map between keychain ID and the keystore information.
+type Schema map[uuid.UUID]*Meta
+
 // NewInMemoryKeystore returns an instance of InMemoryKeystore which implements
 // the Keystore interface.
 func NewInMemoryKeystore() Keystore {
@@ -26,10 +28,6 @@ func NewInMemoryKeystore() Keystore {
 	}
 }
 
-// Get returns a previously stored keychain information based on the provided
-// keychain UUID.
-//
-// Returns an error if the keychain UUID is missing in the keystore.
 func (s *InMemoryKeystore) Get(id uuid.UUID) (KeychainInfo, error) {
 	document, ok := s.db[id]
 	if !ok {
@@ -39,7 +37,6 @@ func (s *InMemoryKeystore) Get(id uuid.UUID) (KeychainInfo, error) {
 	return document.Main, nil
 }
 
-// Delete removes a keychain corresponding to a UUID from the keystore.
 func (s *InMemoryKeystore) Delete(id uuid.UUID) error {
 	_, ok := s.db[id]
 	if !ok {
@@ -51,245 +48,70 @@ func (s *InMemoryKeystore) Delete(id uuid.UUID) error {
 	return nil
 }
 
-// Reset removes derivations and addresses of a keychain corresponding to a UUID from the keystore.
 func (s *InMemoryKeystore) Reset(id uuid.UUID) error {
-	keychain, ok := s.db[id]
+	meta, ok := s.db[id]
 	if !ok {
 		return ErrKeychainNotFound
 	}
 
-	keychain.ResetKeychainMeta()
+	keystoreReset(meta)
 
 	return nil
 }
 
-// Create parses a populates the in-memory keystore with the corresponding
-// keychain information, based on the provided extended public key, Scheme,
-// and Network information.
-//
-// Only initial state is populated, so no addresses will be inserted into the
-// keystore by this method.
 func (s *InMemoryKeystore) Create(
 	extendedPublicKey string, fromChainCode *FromChainCode, scheme Scheme, net chaincfg.Network, lookaheadSize uint32,
 ) (KeychainInfo, error) {
-	if fromChainCode != nil {
-		res, err := GetAccountExtendedKey(s.client, net, fromChainCode)
-		if err != nil {
-			return KeychainInfo{}, errors.Wrapf(err,
-				"failed to get extendend public key from chain code, request = %v", fromChainCode)
-		}
 
-		extendedPublicKey = res.ExtendedKey
-	}
+	meta, err := keystoreCreate(
+		extendedPublicKey,
+		fromChainCode,
+		scheme,
+		net,
+		lookaheadSize,
+		s.client,
+	)
 
-	internalDescriptor, err := MakeDescriptor(extendedPublicKey, Internal, scheme)
 	if err != nil {
-		return KeychainInfo{}, errors.Wrapf(err,
-			"failed to make internal descriptor, xkey = %v", extendedPublicKey)
+		return KeychainInfo{}, err
 	}
 
-	externalDescriptor, err := MakeDescriptor(extendedPublicKey, External, scheme)
-	if err != nil {
-		return KeychainInfo{}, errors.Wrapf(err,
-			"failed to make internal descriptor, xkey = %v", extendedPublicKey)
-	}
+	s.db[meta.Main.ID] = &meta
 
-	externalChild, err := childKDF(s.client, extendedPublicKey, 0)
-	if err != nil {
-		return KeychainInfo{}, errors.Wrapf(
-			err, "failed to derive xpub %v at index %v", extendedPublicKey, 0)
-	}
-
-	internalChild, err := childKDF(s.client, extendedPublicKey, 1)
-	if err != nil {
-		return KeychainInfo{}, errors.Wrapf(
-			err, "failed to derive xpub %v at index %v", extendedPublicKey, 1)
-	}
-
-	id := uuid.New()
-
-	keychainInfo := KeychainInfo{
-		ID:                          id,
-		InternalDescriptor:          internalDescriptor,
-		ExternalDescriptor:          externalDescriptor,
-		ExtendedPublicKey:           extendedPublicKey,
-		SLIP32ExtendedPublicKey:     extendedPublicKey, // TODO: Convert ExtendedPublicKey to SLIP-0132 form
-		ExternalXPub:                externalChild.ExtendedKey,
-		MaxConsecutiveExternalIndex: 0,
-		InternalXPub:                internalChild.ExtendedKey,
-		MaxConsecutiveInternalIndex: 0,
-		LookaheadSize:               lookaheadSize,
-		Scheme:                      scheme,
-		Network:                     net,
-	}
-
-	s.db[id] = &Meta{
-		Main:        keychainInfo,
-		Derivations: map[DerivationPath]string{},
-		Addresses:   map[string]DerivationPath{},
-	}
-
-	return keychainInfo, nil
+	return meta.Main, nil
 }
 
-// GetFreshAddress retrieves an unused address from the in-memory keystore at a
-// given Change index, for the keychain corresponding to the provided keychain
-// ID.
-//
-// See GetFreshAddresses for getting fresh addresses in bulk, and for further
-// details.
 func (s InMemoryKeystore) GetFreshAddress(id uuid.UUID, change Change) (*AddressInfo, error) {
-	addrs, err := s.GetFreshAddresses(id, change, 1)
-	if err != nil {
-		return nil, err
-	}
-
-	return &addrs[0], nil
+	return keystoreGetFreshAddress(&s, id, change)
 }
 
-// GetFreshAddresses retrieves bulk fresh addresses from the in-memory keystore.
-//
-// In addition to ensuring that issued addresses are always fresh (unused), the
-// method also detects gaps in used addresses and includes it in fresh address
-// list.
 func (s InMemoryKeystore) GetFreshAddresses(
 	id uuid.UUID, change Change, size uint32,
 ) ([]AddressInfo, error) {
 	addrs := []AddressInfo{}
 
-	k, ok := s.db[id]
+	meta, ok := s.db[id]
 	if !ok {
 		return addrs, ErrKeychainNotFound
 	}
-
-	maxConsecutiveIndex, err := k.MaxConsecutiveIndex(change)
+	addrs, _, err := keystoreGetFreshAddresses(*meta, s.client, id, change, size)
 	if err != nil {
 		return addrs, err
-	}
-
-	nonConsecutiveIndexes, err := k.NonConsecutiveIndexes(change)
-	if err != nil {
-		return nil, err
-	}
-
-	for i := uint32(0); uint32(len(addrs)) < size; i++ {
-		index := maxConsecutiveIndex + i
-
-		// Skip any index that exists in non-consecutive indexes, to prevent
-		// address reuse.
-		if !contains(nonConsecutiveIndexes, index) {
-			path := DerivationPath{uint32(change), index}
-
-			addr, err := deriveAddress(s.client, k, path)
-			if err != nil {
-				return addrs, err
-			}
-
-			addrInfo := AddressInfo{
-				Address:    addr,
-				Derivation: path,
-				Change:     change,
-			}
-
-			addrs = append(addrs, addrInfo)
-		}
 	}
 
 	return addrs, nil
 }
 
-// MarkPathAsUsed sets a given derivation path as used. It records bookkeeping
-// information about gaps in the derivation.
-//
-// A derivation path is considered "used" if it has transaction history.
-//
-// If marking of a derivation path as used introduces any gaps, they are
-// detected and saved in the keystore. For this we rely on two main fields:
-//   MaxConsecutiveIndex   -> the largest consecutive index without any gaps
-//   NonConsecutiveIndexes -> list of used indexes that introduced gaps
 func (s *InMemoryKeystore) MarkPathAsUsed(id uuid.UUID, path DerivationPath) error {
 	// Get keychain by ID
-	k, ok := s.db[id]
+	meta, ok := s.db[id]
 	if !ok {
 		return ErrKeychainNotFound
 	}
 
-	change := path.ChangeIndex()
-
-	maxConsecutiveIndex, err := k.MaxConsecutiveIndex(change)
+	err := keystoreMarkPathAsUsed(meta, id, path) // meta is changed
 	if err != nil {
 		return err
-	}
-
-	nonConsecutiveIndexes, err := k.NonConsecutiveIndexes(change)
-	if err != nil {
-		return err
-	}
-
-	switch {
-	// CASE 1: Address index being marked as used already falls within the
-	// range of consecutive indexes. This is typically when an address index
-	// is marked as used twice.
-	case path.AddressIndex() < maxConsecutiveIndex:
-		// Nothing to do in this case.
-
-	// CASE 2: Mark as used at the boundary of the consecutive used indexes, by
-	// incrementing the max consecutive index.
-	case path.AddressIndex() == maxConsecutiveIndex:
-		maxConsecutiveIndex++
-
-		// Handle case when the max consecutive index overreaches into the
-		// non-consecutive indexes. This typically happens when a gap is filled
-		// by marking the gap address index as used.
-		//
-		// Repeat this step until the max consecutive index is outside the
-		// overlap of non-consecutive indexes, where it is safe to issue a
-		// fresh address.
-		for contains(nonConsecutiveIndexes, maxConsecutiveIndex) {
-			maxConsecutiveIndex++
-		}
-
-		// Save the max consecutive index. It is important to perform this step
-		// before saving the non-consecutive indexes.
-		if err := k.SetMaxConsecutiveIndex(change, maxConsecutiveIndex); err != nil {
-			return err
-		}
-
-		// Reconcile non-consecutive indexes depending on the updated state of
-		// the max consecutive index.
-		//
-		// TODO: Implement a dedicated method for this reconciliation, since the
-		//       non-consecutive indexes are never changed until this step.
-		if err := k.SetNonConsecutiveIndexes(change, nonConsecutiveIndexes); err != nil {
-			return err
-		}
-
-	// CASE 3: Attempt to introduce a gap after the max consecutive index.
-	//
-	// Consider the following list of address indexes as the state of the
-	// keychain. * indicates that an index is used.
-	//
-	// Before:
-	//   state                  : 0*  1  2  3  4  5
-	//   max consecutive index  : 1
-	//   non-consecutive indexes: []
-	//
-	// After: mark index 2 as used
-	//   state                  : 0*  1  2*  3  4  5
-	//   max consecutive index  : 1   <- no change
-	//   non-consecutive indexes: [2] <- add the index that created a gap
-	case path.AddressIndex() > maxConsecutiveIndex:
-		// Add address index to list of non-consecutive indexes (if does not
-		// exist already).
-		if !contains(nonConsecutiveIndexes, path.AddressIndex()) {
-			nonConsecutiveIndexes = append(
-				nonConsecutiveIndexes, path.AddressIndex())
-
-			err := k.SetNonConsecutiveIndexes(change, nonConsecutiveIndexes)
-			if err != nil {
-				return err
-			}
-		}
 	}
 
 	return nil
@@ -298,93 +120,35 @@ func (s *InMemoryKeystore) MarkPathAsUsed(id uuid.UUID, path DerivationPath) err
 func (s *InMemoryKeystore) GetAllObservableAddresses(
 	id uuid.UUID, change Change, fromIndex uint32, toIndex uint32,
 ) ([]AddressInfo, error) {
-	k, ok := s.db[id]
+	meta, ok := s.db[id]
 	if !ok {
 		return nil, ErrKeychainNotFound
 	}
-
-	maxObservableIndex, err := k.MaxObservableIndex(change)
-	if err != nil {
-		return nil, err
-	}
-
-	length := minUint32(toIndex, maxObservableIndex) - fromIndex
-
-	var result []uint32
-
-	for i := uint32(0); i <= length; i++ {
-		result = append(result, fromIndex+i)
-	}
-
-	addrs := make([]AddressInfo, 0, len(result))
-
-	for _, i := range result {
-		path := DerivationPath{uint32(change), i}
-
-		addr, err := deriveAddress(s.client, k, path)
-		if err != nil {
-			return nil, err
-		}
-
-		addrInfo := AddressInfo{
-			Address:    addr,
-			Derivation: path,
-			Change:     change,
-		}
-
-		addrs = append(addrs, addrInfo)
-	}
-
-	return addrs, nil
+	return keystoreGetAllObservableAddresses(
+		meta, s.client, id, change, fromIndex, toIndex,
+	)
 }
 
-// GetDerivationPath reads the address-to-derivations mapping in the keystore,
-// and returns the DerivationPath corresponding to the specified address.
 func (s InMemoryKeystore) GetDerivationPath(id uuid.UUID, address string) (DerivationPath, error) {
-	k, ok := s.db[id]
+	meta, ok := s.db[id]
 	if !ok {
 		return DerivationPath{}, ErrKeychainNotFound
 	}
 
-	path, ok := k.Addresses[address]
-	if !ok {
-		return DerivationPath{}, ErrAddressNotFound
-	}
-
-	return path, nil
+	return keystoreGetDerivationPath(*meta, id, address)
 }
 
-// MarkAddressAsUsed is a helper to directly mark an address as used. It
-// internally fetches the derivation path of the address from the keystore,
-// and then marks this DerivationPath value as used.
 func (s *InMemoryKeystore) MarkAddressAsUsed(id uuid.UUID, address string) error {
-	path, err := s.GetDerivationPath(id, address)
-	if err != nil {
-		return err
-	}
-
-	return s.MarkPathAsUsed(id, path)
+	return keystoreMarkAddressAsUsed(s, id, address)
 }
 
 // GetAddressesPublicKeys reads the derivation-to-publicKey mapping in the keystore,
 // and returns extendend public keys corresponding to given derivations.
 func (s *InMemoryKeystore) GetAddressesPublicKeys(id uuid.UUID, derivations []DerivationPath) ([]string, error) {
-	k, ok := s.db[id]
+	meta, ok := s.db[id]
 	if !ok {
 		return nil, ErrKeychainNotFound
 	}
 
-	publicKeys := make([]string, len(derivations))
-
-	for idx, derivation := range derivations {
-		publicKey, ok := k.Derivations[derivation]
-
-		if !ok {
-			return nil, ErrDerivationNotFound
-		}
-
-		publicKeys[idx] = publicKey
-	}
-
-	return publicKeys, nil
+	return keystoreGetAddressesPublicKeys(*meta, id, derivations)
 }

--- a/pkg/keystore/memory_test.go
+++ b/pkg/keystore/memory_test.go
@@ -86,7 +86,7 @@ func (c mockBitcoinClient) EncodeAddress(
 
 func NewMockInMemoryKeystore() Keystore {
 	return &InMemoryKeystore{
-		db:     Schema{},
+		db:     schema{},
 		client: mockBitcoinClient{},
 	}
 }

--- a/pkg/keystore/redis.go
+++ b/pkg/keystore/redis.go
@@ -7,10 +7,8 @@ import (
 
 	"github.com/go-redis/redis/v8"
 	"github.com/google/uuid"
-	"github.com/ledgerhq/bitcoin-keychain/log"
 	"github.com/ledgerhq/bitcoin-keychain/pb/bitcoin"
 	"github.com/ledgerhq/bitcoin-keychain/pkg/chaincfg"
-	"github.com/pkg/errors"
 )
 
 // RedisKeystore implements the Keystore interface where the storage
@@ -38,10 +36,6 @@ func NewRedisKeystore(redisOpts *redis.Options) (*RedisKeystore, error) {
 	}, nil
 }
 
-// Get returns a previously stored keychain information based on the provided
-// keychain UUID.
-//
-// Returns an error if the keychain UUID is missing in the keystore.
 func (s *RedisKeystore) Get(id uuid.UUID) (KeychainInfo, error) {
 	var meta Meta
 
@@ -53,7 +47,6 @@ func (s *RedisKeystore) Get(id uuid.UUID) (KeychainInfo, error) {
 	return meta.Main, nil
 }
 
-// Delete removes a keychain corresponding to a UUID from the keystore.
 func (s *RedisKeystore) Delete(id uuid.UUID) error {
 	var meta Meta
 
@@ -67,7 +60,6 @@ func (s *RedisKeystore) Delete(id uuid.UUID) error {
 	return nil
 }
 
-// Reset removes derivations and addresses of a keychain corresponding to a UUID from the keystore.
 func (s *RedisKeystore) Reset(id uuid.UUID) error {
 	var meta Meta
 
@@ -76,7 +68,7 @@ func (s *RedisKeystore) Reset(id uuid.UUID) error {
 		return ErrKeychainNotFound
 	}
 
-	meta.ResetKeychainMeta()
+	keystoreReset(&meta)
 
 	if err := set(s.db, id.String(), meta); err != nil {
 		return err
@@ -85,327 +77,112 @@ func (s *RedisKeystore) Reset(id uuid.UUID) error {
 	return nil
 }
 
-// Create parses a populates the in-memory keystore with the corresponding
-// keychain information, based on the provided extended public key, Scheme,
-// and Network information.
-//
-// Only initial state is populated, so no addresses will be inserted into the
-// keystore by this method.
 func (s *RedisKeystore) Create(
 	extendedPublicKey string, fromChainCode *FromChainCode, scheme Scheme, net chaincfg.Network, lookaheadSize uint32,
 ) (KeychainInfo, error) {
-	if fromChainCode != nil {
-		res, err := GetAccountExtendedKey(s.client, net, fromChainCode)
-		if err != nil {
-			return KeychainInfo{}, errors.Wrapf(err,
-				"failed to get extendend public key from chain code, request = %v", fromChainCode)
-		}
+	meta, err := keystoreCreate(
+		extendedPublicKey,
+		fromChainCode,
+		scheme,
+		net,
+		lookaheadSize,
+		s.client,
+	)
 
-		extendedPublicKey = res.ExtendedKey
-	}
-
-	internalDescriptor, err := MakeDescriptor(extendedPublicKey, Internal, scheme)
 	if err != nil {
-		return KeychainInfo{}, errors.Wrapf(err,
-			"failed to make internal descriptor, xkey = %v", extendedPublicKey)
-	}
-
-	externalDescriptor, err := MakeDescriptor(extendedPublicKey, External, scheme)
-	if err != nil {
-		return KeychainInfo{}, errors.Wrapf(err,
-			"failed to make internal descriptor, xkey = %v", extendedPublicKey)
-	}
-
-	externalChild, err := childKDF(s.client, extendedPublicKey, 0)
-	if err != nil {
-		return KeychainInfo{}, errors.Wrapf(
-			err, "failed to derive xpub %v at index %v", extendedPublicKey, 0)
-	}
-
-	internalChild, err := childKDF(s.client, extendedPublicKey, 1)
-	if err != nil {
-		return KeychainInfo{}, errors.Wrapf(
-			err, "failed to derive xpub %v at index %v", extendedPublicKey, 1)
-	}
-
-	id := uuid.New()
-
-	keychainInfo := KeychainInfo{
-		ID:                          id,
-		InternalDescriptor:          internalDescriptor,
-		ExternalDescriptor:          externalDescriptor,
-		ExtendedPublicKey:           extendedPublicKey,
-		SLIP32ExtendedPublicKey:     extendedPublicKey, // TODO: Convert ExtendedPublicKey to SLIP-0132 form
-		ExternalXPub:                externalChild.ExtendedKey,
-		MaxConsecutiveExternalIndex: 0,
-		InternalXPub:                internalChild.ExtendedKey,
-		MaxConsecutiveInternalIndex: 0,
-		LookaheadSize:               lookaheadSize,
-		Scheme:                      scheme,
-		Network:                     net,
-	}
-
-	meta := Meta{
-		Main:        keychainInfo,
-		Derivations: nil,
-		Addresses:   nil,
-	}
-
-	if err := set(s.db, id.String(), meta); err != nil {
 		return KeychainInfo{}, err
 	}
 
-	return keychainInfo, nil
-}
-
-// GetFreshAddress retrieves an unused address from the in-memory keystore at a
-// given Change index, for the keychain corresponding to the provided keychain
-// ID.
-//
-// See GetFreshAddresses for getting fresh addresses in bulk, and for further
-// details.
-func (s *RedisKeystore) GetFreshAddress(id uuid.UUID, change Change) (*AddressInfo, error) {
-	addrs, err := s.GetFreshAddresses(id, change, 1)
-	if err != nil {
-		return nil, err
+	if err := set(s.db, meta.Main.ID.String(), meta); err != nil {
+		return KeychainInfo{}, err
 	}
 
-	return &addrs[0], nil
+	return meta.Main, nil
 }
 
-// GetFreshAddresses retrieves bulk fresh addresses from the in-memory keystore.
-//
-// In addition to ensuring that issued addresses are always fresh (unused), the
-// method also detects gaps in used addresses and includes it in fresh address
-// list.
+func (s *RedisKeystore) GetFreshAddress(id uuid.UUID, change Change) (*AddressInfo, error) {
+	return keystoreGetFreshAddress(s, id, change)
+}
+
 func (s *RedisKeystore) GetFreshAddresses(
 	id uuid.UUID, change Change, size uint32,
 ) ([]AddressInfo, error) {
-	addrs := []AddressInfo{}
+	var meta Meta
 
-	var k Meta
-
-	err := get(s.db, id.String(), &k)
+	err := get(s.db, id.String(), &meta)
 	if err != nil {
-		return addrs, ErrKeychainNotFound
+		return []AddressInfo{}, ErrKeychainNotFound
 	}
 
-	maxConsecutiveIndex, err := k.MaxConsecutiveIndex(change)
+	addrs, changedMetas, err := keystoreGetFreshAddresses(meta, s.client, id, change, size)
 	if err != nil {
 		return addrs, err
 	}
 
-	nonConsecutiveIndexes, err := k.NonConsecutiveIndexes(change)
-	if err != nil {
-		return nil, err
-	}
-
-	for i := uint32(0); uint32(len(addrs)) < size; i++ {
-		index := maxConsecutiveIndex + i
-
-		// Skip any index that exists in non-consecutive indexes, to prevent
-		// address reuse.
-		if !contains(nonConsecutiveIndexes, index) {
-			path := DerivationPath{uint32(change), index}
-
-			addr, err := deriveAddress(s.client, &k, path)
-			if err != nil {
-				return addrs, err
-			}
-
-			if err := set(s.db, id.String(), k); err != nil {
-				return nil, err
-			}
-
-			addrInfo := AddressInfo{
-				Address:    addr,
-				Derivation: path,
-				Change:     change,
-			}
-
-			addrs = append(addrs, addrInfo)
+	for _, meta := range changedMetas {
+		if err := set(s.db, id.String(), meta); err != nil {
+			return nil, err
 		}
 	}
 
-	return addrs, nil
+	return addrs, err
 }
 
-// MarkPathAsUsed sets a given derivation path as used. It records bookkeeping
-// information about gaps in the derivation.
-//
-// A derivation path is considered "used" if it has transaction history.
-//
-// If marking of a derivation path as used introduces any gaps, they are
-// detected and saved in the keystore. For this we rely on two main fields:
-//   MaxConsecutiveIndex   -> the largest consecutive index without any gaps
-//   NonConsecutiveIndexes -> list of used indexes that introduced gaps
 func (s *RedisKeystore) MarkPathAsUsed(id uuid.UUID, path DerivationPath) error {
 	// Get keychain by ID
-	var k Meta
+	var meta Meta
 
-	err := get(s.db, id.String(), &k)
+	err := get(s.db, id.String(), &meta)
 	if err != nil {
 		return ErrKeychainNotFound
 	}
 
-	change := path.ChangeIndex()
-
-	maxConsecutiveIndex, err := k.MaxConsecutiveIndex(change)
+	err = keystoreMarkPathAsUsed(&meta, id, path)
 	if err != nil {
 		return err
 	}
 
-	nonConsecutiveIndexes, err := k.NonConsecutiveIndexes(change)
-	if err != nil {
-		return err
-	}
-
-	switch {
-	// CASE 1: Address index being marked as used already falls within the
-	// range of consecutive indexes. This is typically when an address index
-	// is marked as used twice.
-	case path.AddressIndex() < maxConsecutiveIndex:
-		// Nothing to do in this case.
-
-	// CASE 2: Mark as used at the boundary of the consecutive used indexes, by
-	// incrementing the max consecutive index.
-	case path.AddressIndex() == maxConsecutiveIndex:
-		maxConsecutiveIndex++
-
-		// Handle case when the max consecutive index overreaches into the
-		// non-consecutive indexes. This typically happens when a gap is filled
-		// by marking the gap address index as used.
-		//
-		// Repeat this step until the max consecutive index is outside the
-		// overlap of non-consecutive indexes, where it is safe to issue a
-		// fresh address.
-		for contains(nonConsecutiveIndexes, maxConsecutiveIndex) {
-			maxConsecutiveIndex++
-		}
-
-		// Save the max consecutive index. It is important to perform this step
-		// before saving the non-consecutive indexes.
-		if err := k.SetMaxConsecutiveIndex(change, maxConsecutiveIndex); err != nil {
-			return err
-		}
-
-		// Reconcile non-consecutive indexes depending on the updated state of
-		// the max consecutive index.
-		//
-		// TODO: Implement a dedicated method for this reconciliation, since the
-		//       non-consecutive indexes are never changed until this step.
-		if err := k.SetNonConsecutiveIndexes(change, nonConsecutiveIndexes); err != nil {
-			return err
-		}
-
-	// CASE 3: Attempt to introduce a gap after the max consecutive index.
-	//
-	// Consider the following list of address indexes as the state of the
-	// keychain. * indicates that an index is used.
-	//
-	// Before:
-	//   state                  : 0*  1  2  3  4  5
-	//   max consecutive index  : 1
-	//   non-consecutive indexes: []
-	//
-	// After: mark index 2 as used
-	//   state                  : 0*  1  2*  3  4  5
-	//   max consecutive index  : 1   <- no change
-	//   non-consecutive indexes: [2] <- add the index that created a gap
-	case path.AddressIndex() > maxConsecutiveIndex:
-		// Add address index to list of non-consecutive indexes (if does not
-		// exist already).
-		if !contains(nonConsecutiveIndexes, path.AddressIndex()) {
-			nonConsecutiveIndexes = append(
-				nonConsecutiveIndexes, path.AddressIndex())
-
-			err := k.SetNonConsecutiveIndexes(change, nonConsecutiveIndexes)
-			if err != nil {
-				return err
-			}
-		}
-	}
-
-	return set(s.db, id.String(), k)
+	return set(s.db, id.String(), meta)
 }
 
 func (s *RedisKeystore) GetAllObservableAddresses(
 	id uuid.UUID, change Change, fromIndex uint32, toIndex uint32,
 ) ([]AddressInfo, error) {
-	var k Meta
+	var meta Meta
 
-	err := get(s.db, id.String(), &k)
+	err := get(s.db, id.String(), &meta)
 	if err != nil {
 		return nil, ErrKeychainNotFound
 	}
 
-	maxObservableIndex, err := k.MaxObservableIndex(change)
+	addrs, err := keystoreGetAllObservableAddresses(
+		&meta, s.client, id, change, fromIndex, toIndex,
+	)
 	if err != nil {
-		return nil, err
+		return addrs, err
 	}
 
-	length := minUint32(toIndex, maxObservableIndex) - fromIndex
-
-	log.WithFields(log.Fields{
-		"maxObservable": maxObservableIndex,
-		"givenRange":    []uint32{fromIndex, toIndex},
-		"computedRange": []uint32{fromIndex, fromIndex + length},
-	}).Info("[keystore] GetAllObservableAddresses: compute range")
-
-	addrs := []AddressInfo{}
-
-	for i := fromIndex; i <= fromIndex+length; i++ {
-		path := DerivationPath{uint32(change), i}
-
-		addr, err := deriveAddress(s.client, &k, path)
-		if err != nil {
-			return nil, err
-		}
-
-		addrInfo := AddressInfo{
-			Address:    addr,
-			Derivation: path,
-			Change:     change,
-		}
-
-		addrs = append(addrs, addrInfo)
-	}
-
-	if err := set(s.db, id.String(), k); err != nil {
-		return nil, err
+	err = set(s.db, id.String(), meta)
+	if err != nil {
+		return addrs, err
 	}
 
 	return addrs, nil
+
 }
 
-// GetDerivationPath reads the address-to-derivations mapping in the keystore,
-// and returns the DerivationPath corresponding to the specified address.
 func (s *RedisKeystore) GetDerivationPath(id uuid.UUID, address string) (DerivationPath, error) {
-	var k Meta
-
-	err := get(s.db, id.String(), &k)
+	var meta Meta
+	err := get(s.db, id.String(), &meta)
 	if err != nil {
 		return DerivationPath{}, ErrKeychainNotFound
 	}
 
-	path, ok := k.Addresses[address]
-	if !ok {
-		return DerivationPath{}, ErrAddressNotFound
-	}
-
-	return path, nil
+	return keystoreGetDerivationPath(meta, id, address)
 }
 
-// MarkAddressAsUsed is a helper to directly mark an address as used. It
-// internally fetches the derivation path of the address from the keystore,
-// and then marks this DerivationPath value as used.
 func (s *RedisKeystore) MarkAddressAsUsed(id uuid.UUID, address string) error {
-	path, err := s.GetDerivationPath(id, address)
-	if err != nil {
-		return err
-	}
-
-	return s.MarkPathAsUsed(id, path)
+	return keystoreMarkAddressAsUsed(s, id, address)
 }
 
 func set(c *redis.Client, key string, value interface{}) error {
@@ -426,27 +203,13 @@ func get(c *redis.Client, key string, dest interface{}) error {
 	return json.Unmarshal([]byte(p), dest)
 }
 
-// GetAddressesPublicKeys reads the derivation-to-publicKey mapping in the keystore,
-// and returns extendend public keys corresponding to given derivations.
 func (s *RedisKeystore) GetAddressesPublicKeys(id uuid.UUID, derivations []DerivationPath) ([]string, error) {
-	var k Meta
+	var meta Meta
 
-	err := get(s.db, id.String(), &k)
+	err := get(s.db, id.String(), &meta)
 	if err != nil {
 		return nil, ErrKeychainNotFound
 	}
 
-	publicKeys := make([]string, len(derivations))
-
-	for idx, derivation := range derivations {
-		publicKey, ok := k.Derivations[derivation]
-
-		if !ok {
-			return nil, ErrDerivationNotFound
-		}
-
-		publicKeys[idx] = publicKey
-	}
-
-	return publicKeys, nil
+	return keystoreGetAddressesPublicKeys(meta, id, derivations)
 }

--- a/pkg/keystore/redis.go
+++ b/pkg/keystore/redis.go
@@ -118,7 +118,7 @@ func (s *RedisKeystore) GetFreshAddresses(
 		return []AddressInfo{}, ErrKeychainNotFound
 	}
 
-	addrs, err := meta.keystoreGetFreshAddresses(s.client, id, change, size)
+	addrs, err := meta.keystoreGetFreshAddresses(s.client, change, size)
 	if err != nil {
 		return addrs, err
 	}
@@ -158,7 +158,7 @@ func (s *RedisKeystore) GetAllObservableAddresses(
 	}
 
 	addrs, err := meta.keystoreGetAllObservableAddresses(
-		s.client, id, change, fromIndex, toIndex,
+		s.client, change, fromIndex, toIndex,
 	)
 	if err != nil {
 		return addrs, err
@@ -170,7 +170,6 @@ func (s *RedisKeystore) GetAllObservableAddresses(
 	}
 
 	return addrs, nil
-
 }
 
 func (s *RedisKeystore) GetDerivationPath(id uuid.UUID, address string) (DerivationPath, error) {

--- a/pkg/keystore/store.go
+++ b/pkg/keystore/store.go
@@ -431,11 +431,9 @@ func keystoreCreate(
 
 func (m *Meta) keystoreGetFreshAddresses(
 	client bitcoin.CoinServiceClient,
-	id uuid.UUID,
 	change Change,
 	size uint32,
 ) ([]AddressInfo, error) {
-
 	addrs := []AddressInfo{}
 	maxConsecutiveIndex, err := m.MaxConsecutiveIndex(change)
 	if err != nil {
@@ -555,7 +553,6 @@ func (m *Meta) keystoreMarkPathAsUsed(path DerivationPath) error {
 
 func (m *Meta) keystoreGetAllObservableAddresses(
 	client bitcoin.CoinServiceClient,
-	id uuid.UUID,
 	change Change,
 	fromIndex uint32,
 	toIndex uint32,
@@ -612,11 +609,11 @@ func keystoreMarkAddressAsUsed(s Keystore, id uuid.UUID, address string) error {
 	return s.MarkPathAsUsed(id, path)
 }
 
-func (meta *Meta) keystoreGetAddressesPublicKeys(derivations []DerivationPath) ([]string, error) {
+func (m *Meta) keystoreGetAddressesPublicKeys(derivations []DerivationPath) ([]string, error) {
 	publicKeys := make([]string, len(derivations))
 
 	for idx, derivation := range derivations {
-		publicKey, ok := meta.Derivations[derivation]
+		publicKey, ok := m.Derivations[derivation]
 
 		if !ok {
 			return nil, ErrDerivationNotFound

--- a/pkg/keystore/store.go
+++ b/pkg/keystore/store.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 
 	"github.com/google/uuid"
+	"github.com/ledgerhq/bitcoin-keychain/log"
+	"github.com/ledgerhq/bitcoin-keychain/pb/bitcoin"
 	"github.com/ledgerhq/bitcoin-keychain/pkg/chaincfg"
 	"github.com/pkg/errors"
 )
@@ -14,20 +16,59 @@ import (
 // Keystore is an interface that all keychain storage backends must implement.
 // Currently, there are two Keystore implementations available:
 //   InMemoryKeystore: useful for unit-tests
-//   RedisKeystore:    TBA
+//   RedisKeystore:    for production
 type Keystore interface {
+	// Get returns a previously stored keychain information based on the provided
+	// keychain UUID.
+	//
+	// Returns an error if the keychain UUID is missing in the keystore.
 	Get(id uuid.UUID) (KeychainInfo, error)
+	// Delete removes a keychain corresponding to a UUID from the keystore.
 	Delete(id uuid.UUID) error
+	// Reset removes derivations and addresses of a keychain corresponding to a UUID from the keystore.
 	Reset(id uuid.UUID) error
+	// Create parses a populates the keystore with the corresponding
+	// keychain information, based on the provided extended public key, Scheme,
+	// and Network information.
+	//
+	// Only initial state is populated, so no addresses will be inserted into the
+	// keystore by this method.
 	Create(extendedPublicKey string, fromChainCode *FromChainCode, scheme Scheme, net chaincfg.Network,
 		lookaheadSize uint32) (KeychainInfo, error)
+	// GetFreshAddress retrieves an unused address from the keystore at a
+	// given Change index, for the keychain corresponding to the provided keychain
+	// ID.
+	//
+	// See GetFreshAddresses for getting fresh addresses in bulk, and for further
+	// details.
 	GetFreshAddress(id uuid.UUID, change Change) (*AddressInfo, error)
+	// GetFreshAddresses retrieves bulk fresh addresses from the keystore.
+	//
+	// In addition to ensuring that issued addresses are always fresh (unused), the
+	// method also detects gaps in used addresses and includes it in fresh address
+	// list.
 	GetFreshAddresses(id uuid.UUID, change Change, size uint32) ([]AddressInfo, error)
+	// MarkPathAsUsed sets a given derivation path as used. It records bookkeeping
+	// information about gaps in the derivation.
+	//
+	// A derivation path is considered "used" if it has transaction history.
+	//
+	// If marking of a derivation path as used introduces any gaps, they are
+	// detected and saved in the keystore. For this we rely on two main fields:
+	//   MaxConsecutiveIndex   -> the largest consecutive index without any gaps
+	//   NonConsecutiveIndexes -> list of used indexes that introduced gaps
 	MarkPathAsUsed(id uuid.UUID, path DerivationPath) error
+	// MarkAddressAsUsed is a helper to directly mark an address as used. It
+	// internally fetches the derivation path of the address from the keystore,
+	// and then marks this DerivationPath value as used.
 	MarkAddressAsUsed(id uuid.UUID, address string) error
 	GetAllObservableAddresses(id uuid.UUID, change Change,
 		fromIndex uint32, toIndex uint32) ([]AddressInfo, error)
+	// GetDerivationPath reads the address-to-derivations mapping in the keystore,
+	// and returns the DerivationPath corresponding to the specified address.
 	GetDerivationPath(id uuid.UUID, address string) (DerivationPath, error)
+	// GetAddressesPublicKeys reads the derivation-to-publicKey mapping in the keystore,
+	// and returns extendend public keys corresponding to given derivations.
 	GetAddressesPublicKeys(id uuid.UUID, derivations []DerivationPath) ([]string, error)
 }
 
@@ -70,9 +111,6 @@ type KeychainInfo struct {
 	NonConsecutiveExternalIndexes []uint32         `json:"non_consecutive_external_indexes"` // Used external indexes that are creating a gap in the derivation
 	NonConsecutiveInternalIndexes []uint32         `json:"non_consecutive_internal_indexes"` // Used internal indexes that are creating a gap in the derivation
 }
-
-// Schema is a map between keychain ID and the keystore information.
-type Schema map[uuid.UUID]*Meta
 
 // Meta is a struct containing account details corresponding to a keychain ID,
 // such as derivations, addresses, etc.
@@ -321,4 +359,288 @@ func (m *Meta) ResetKeychainMeta() {
 	m.Main.MaxConsecutiveInternalIndex = 0
 	m.Derivations = map[DerivationPath]string{}
 	m.Addresses = map[string]DerivationPath{}
+}
+
+func keystoreReset(meta *Meta) {
+	meta.ResetKeychainMeta()
+}
+
+func keystoreCreate(
+	extendedPublicKey string,
+	fromChainCode *FromChainCode,
+	scheme Scheme,
+	net chaincfg.Network,
+	lookaheadSize uint32,
+	client bitcoin.CoinServiceClient,
+) (Meta, error) {
+	if fromChainCode != nil {
+		res, err := GetAccountExtendedKey(client, net, fromChainCode)
+		if err != nil {
+			return Meta{}, errors.Wrapf(err,
+				"failed to get extendend public key from chain code, request = %v", fromChainCode)
+		}
+
+		extendedPublicKey = res.ExtendedKey
+	}
+
+	internalDescriptor, err := MakeDescriptor(extendedPublicKey, Internal, scheme)
+	if err != nil {
+		return Meta{}, errors.Wrapf(err,
+			"failed to make internal descriptor, xkey = %v", extendedPublicKey)
+	}
+
+	externalDescriptor, err := MakeDescriptor(extendedPublicKey, External, scheme)
+	if err != nil {
+		return Meta{}, errors.Wrapf(err,
+			"failed to make internal descriptor, xkey = %v", extendedPublicKey)
+	}
+
+	externalChild, err := childKDF(client, extendedPublicKey, 0)
+	if err != nil {
+		return Meta{}, errors.Wrapf(
+			err, "failed to derive xpub %v at index %v", extendedPublicKey, 0)
+	}
+
+	internalChild, err := childKDF(client, extendedPublicKey, 1)
+	if err != nil {
+		return Meta{}, errors.Wrapf(
+			err, "failed to derive xpub %v at index %v", extendedPublicKey, 1)
+	}
+
+	id := uuid.New()
+
+	keychainInfo := KeychainInfo{
+		ID:                          id,
+		InternalDescriptor:          internalDescriptor,
+		ExternalDescriptor:          externalDescriptor,
+		ExtendedPublicKey:           extendedPublicKey,
+		SLIP32ExtendedPublicKey:     extendedPublicKey, // TODO: Convert ExtendedPublicKey to SLIP-0132 form
+		ExternalXPub:                externalChild.ExtendedKey,
+		MaxConsecutiveExternalIndex: 0,
+		InternalXPub:                internalChild.ExtendedKey,
+		MaxConsecutiveInternalIndex: 0,
+		LookaheadSize:               lookaheadSize,
+		Scheme:                      scheme,
+		Network:                     net,
+	}
+
+	meta := Meta{
+		Main:        keychainInfo,
+		Derivations: map[DerivationPath]string{},
+		Addresses:   map[string]DerivationPath{},
+	}
+
+	return meta, nil
+}
+
+func keystoreGetFreshAddress(s Keystore, id uuid.UUID, change Change) (*AddressInfo, error) {
+	addrs, err := s.GetFreshAddresses(id, change, 1)
+	if err != nil {
+		return nil, err
+	}
+
+	return &addrs[0], nil
+}
+
+func keystoreGetFreshAddresses(
+	meta Meta,
+	client bitcoin.CoinServiceClient,
+	id uuid.UUID,
+	change Change,
+	size uint32,
+) ([]AddressInfo, []Meta, error) {
+
+	addrs := []AddressInfo{}
+	changedMetas := []Meta{}
+	maxConsecutiveIndex, err := meta.MaxConsecutiveIndex(change)
+	if err != nil {
+		return addrs, changedMetas, err
+	}
+
+	nonConsecutiveIndexes, err := meta.NonConsecutiveIndexes(change)
+	if err != nil {
+		return nil, changedMetas, err
+	}
+
+	for i := uint32(0); uint32(len(addrs)) < size; i++ {
+		index := maxConsecutiveIndex + i
+
+		// Skip any index that exists in non-consecutive indexes, to prevent
+		// address reuse.
+		if !contains(nonConsecutiveIndexes, index) {
+			path := DerivationPath{uint32(change), index}
+
+			addr, err := deriveAddress(client, &meta, path)
+			if err != nil {
+				return addrs, changedMetas, err
+			}
+
+			addrInfo := AddressInfo{
+				Address:    addr,
+				Derivation: path,
+				Change:     change,
+			}
+
+			addrs = append(addrs, addrInfo)
+			changedMetas = append(changedMetas, meta)
+		}
+	}
+	return addrs, changedMetas, nil
+}
+
+func keystoreMarkPathAsUsed(meta *Meta, id uuid.UUID, path DerivationPath) error {
+	change := path.ChangeIndex()
+
+	maxConsecutiveIndex, err := meta.MaxConsecutiveIndex(change)
+	if err != nil {
+		return err
+	}
+
+	nonConsecutiveIndexes, err := meta.NonConsecutiveIndexes(change)
+	if err != nil {
+		return err
+	}
+
+	switch {
+	// CASE 1: Address index being marked as used already falls within the
+	// range of consecutive indexes. This is typically when an address index
+	// is marked as used twice.
+	case path.AddressIndex() < maxConsecutiveIndex:
+		// Nothing to do in this case.
+
+	// CASE 2: Mark as used at the boundary of the consecutive used indexes, by
+	// incrementing the max consecutive index.
+	case path.AddressIndex() == maxConsecutiveIndex:
+		maxConsecutiveIndex++
+
+		// Handle case when the max consecutive index overreaches into the
+		// non-consecutive indexes. This typically happens when a gap is filled
+		// by marking the gap address index as used.
+		//
+		// Repeat this step until the max consecutive index is outside the
+		// overlap of non-consecutive indexes, where it is safe to issue a
+		// fresh address.
+		for contains(nonConsecutiveIndexes, maxConsecutiveIndex) {
+			maxConsecutiveIndex++
+		}
+
+		// Save the max consecutive index. It is important to perform this step
+		// before saving the non-consecutive indexes.
+		if err := meta.SetMaxConsecutiveIndex(change, maxConsecutiveIndex); err != nil {
+			return err
+		}
+
+		// Reconcile non-consecutive indexes depending on the updated state of
+		// the max consecutive index.
+		//
+		// TODO: Implement a dedicated method for this reconciliation, since the
+		//       non-consecutive indexes are never changed until this step.
+		if err := meta.SetNonConsecutiveIndexes(change, nonConsecutiveIndexes); err != nil {
+			return err
+		}
+
+	// CASE 3: Attempt to introduce a gap after the max consecutive index.
+	//
+	// Consider the following list of address indexes as the state of the
+	// keychain. * indicates that an index is used.
+	//
+	// Before:
+	//   state                  : 0*  1  2  3  4  5
+	//   max consecutive index  : 1
+	//   non-consecutive indexes: []
+	//
+	// After: mark index 2 as used
+	//   state                  : 0*  1  2*  3  4  5
+	//   max consecutive index  : 1   <- no change
+	//   non-consecutive indexes: [2] <- add the index that created a gap
+	case path.AddressIndex() > maxConsecutiveIndex:
+		// Add address index to list of non-consecutive indexes (if does not
+		// exist already).
+		if !contains(nonConsecutiveIndexes, path.AddressIndex()) {
+			nonConsecutiveIndexes = append(
+				nonConsecutiveIndexes, path.AddressIndex())
+
+			err := meta.SetNonConsecutiveIndexes(change, nonConsecutiveIndexes)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func keystoreGetAllObservableAddresses(
+	meta *Meta,
+	client bitcoin.CoinServiceClient,
+	id uuid.UUID,
+	change Change,
+	fromIndex uint32,
+	toIndex uint32,
+) ([]AddressInfo, error) {
+	maxObservableIndex, err := meta.MaxObservableIndex(change)
+	if err != nil {
+		return nil, err
+	}
+
+	length := minUint32(toIndex, maxObservableIndex) - fromIndex
+
+	log.WithFields(log.Fields{
+		"maxObservable": maxObservableIndex,
+		"givenRange":    []uint32{fromIndex, toIndex},
+		"computedRange": []uint32{fromIndex, fromIndex + length},
+	}).Info("[keystore] GetAllObservableAddresses: compute range")
+
+	addrs := []AddressInfo{}
+
+	for i := fromIndex; i <= fromIndex+length; i++ {
+		path := DerivationPath{uint32(change), i}
+
+		addr, err := deriveAddress(client, meta, path)
+		if err != nil {
+			return nil, err
+		}
+
+		addrInfo := AddressInfo{
+			Address:    addr,
+			Derivation: path,
+			Change:     change,
+		}
+
+		addrs = append(addrs, addrInfo)
+	}
+
+	return addrs, nil
+}
+
+func keystoreGetDerivationPath(meta Meta, id uuid.UUID, address string) (DerivationPath, error) {
+	path, ok := meta.Addresses[address]
+	if !ok {
+		return DerivationPath{}, ErrAddressNotFound
+	}
+	return path, nil
+}
+
+func keystoreMarkAddressAsUsed(s Keystore, id uuid.UUID, address string) error {
+	path, err := s.GetDerivationPath(id, address)
+	if err != nil {
+		return err
+	}
+
+	return s.MarkPathAsUsed(id, path)
+}
+
+func keystoreGetAddressesPublicKeys(meta Meta, id uuid.UUID, derivations []DerivationPath) ([]string, error) {
+	publicKeys := make([]string, len(derivations))
+
+	for idx, derivation := range derivations {
+		publicKey, ok := meta.Derivations[derivation]
+
+		if !ok {
+			return nil, ErrDerivationNotFound
+		}
+
+		publicKeys[idx] = publicKey
+	}
+
+	return publicKeys, nil
 }


### PR DESCRIPTION
remove duplication
The real code is moved to function in store.go
memory.go and redis.go do the access layer thing and call those functions