### PR TITLE
Bump go version to v1.16 and fix lint errors

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -11,13 +11,13 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.15
+          go-version: 1.16
 
       - name: Install mage
         run: "pushd /tmp; git clone https://github.com/magefile/mage; pushd mage; go run bootstrap.go; popd; popd"
 
       - name: Install golangci-lint
-        run: "curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.28.0"
+        run: "curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.41.1"
 
       - name: Install Protobuf compiler
         uses: arduino/setup-protoc@master

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.15
+          go-version: 1.16
 
       - name: Install mage
         run: "pushd /tmp; git clone https://github.com/magefile/mage; pushd mage; go run bootstrap.go; popd; popd"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.15-alpine as builder
+FROM golang:1.16-alpine as builder
 
 # System setup
 RUN apk update && apk add git curl build-base autoconf automake libtool

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -56,7 +56,7 @@ func main() {
 		port          int32 = 50052
 		redisHost     string
 		redisPort     int32 = 6379
-		redisDB       int   = 0
+		redisDB       int
 		redisPassword string
 		tlsConfig     *tls.Config
 	)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ledgerhq/bitcoin-keychain
 
-go 1.15
+go 1.16
 
 require (
 	github.com/go-redis/redis/v8 v8.2.3

--- a/magefile.go
+++ b/magefile.go
@@ -113,14 +113,13 @@ func TestRaceCover() error {
 func Lint() error {
 	linterArgs := []string{
 		"run",
-		"-E=golint",
-		"-E=interfacer",
+		"-E=revive",
 		"-E=unconvert",
 		"-E=dupl",
 		"-E=goconst",
 		"-E=gofmt",
 		"-E=goimports",
-		"-E=maligned",
+		"-E=govet",
 		"-E=depguard",
 		"-E=misspell",
 		"-E=whitespace",

--- a/pb/go.mod
+++ b/pb/go.mod
@@ -1,3 +1,3 @@
 module github.com/ledgerhq/bitcoin-keychain/pb
 
-go 1.15
+go 1.16

--- a/pkg/keystore/redis_common.go
+++ b/pkg/keystore/redis_common.go
@@ -49,18 +49,13 @@ func (s *baseRedisKeystore) Reset(id uuid.UUID) error {
 
 	meta.ResetKeychainMeta()
 
-	if err := set(s.db, id.String(), meta); err != nil {
-		return err
-	}
-
-	return nil
+	return set(s.db, id.String(), meta)
 }
 
 func (s *baseRedisKeystore) Create(
 	extendedPublicKey string, fromChainCode *FromChainCode, scheme Scheme,
 	net chaincfg.Network, lookaheadSize uint32, index uint32, metadata string,
 ) (KeychainInfo, error) {
-
 	meta, err := keystoreCreate(
 		extendedPublicKey,
 		fromChainCode,
@@ -81,7 +76,6 @@ func (s *baseRedisKeystore) Create(
 	}
 
 	return meta.Main, nil
-
 }
 
 func (s *baseRedisKeystore) GetDerivationPath(id uuid.UUID, address string) (DerivationPath, error) {

--- a/pkg/keystore/store.go
+++ b/pkg/keystore/store.go
@@ -102,15 +102,15 @@ type KeychainInfo struct {
 	ExtendedPublicKey             string           `json:"extended_public_key"`              // Extended public key serialized with standard HD version bytes
 	SLIP32ExtendedPublicKey       string           `json:"slip32_extended_public_key"`       // Extended public key serialized with SLIP-0132 HD version bytes
 	ExternalXPub                  string           `json:"external_xpub"`                    // External chain extended public key at HD tree depth 4
-	MaxConsecutiveExternalIndex   uint32           `json:"max_consecutive_external_index"`   // Max consecutive index (without any gap) on the external chain
 	InternalXPub                  string           `json:"internal_xpub"`                    // Internal chain extended public key at HD tree depth 4
+	MaxConsecutiveExternalIndex   uint32           `json:"max_consecutive_external_index"`   // Max consecutive index (without any gap) on the external chain
 	MaxConsecutiveInternalIndex   uint32           `json:"max_consecutive_internal_index"`   // Max consecutive index (without any gap) on the internal chain
 	LookaheadSize                 uint32           `json:"lookahead_size"`                   // Numerical size of the lookahead zone
+	AccountIndex                  uint32           `json:"account_index"`                    // Account index
 	Scheme                        Scheme           `json:"scheme"`                           // String identifier for keychain scheme
 	Network                       chaincfg.Network `json:"network"`                          // String denoting the network to use for encoding addresses
 	NonConsecutiveExternalIndexes []uint32         `json:"non_consecutive_external_indexes"` // Used external indexes that are creating a gap in the derivation
 	NonConsecutiveInternalIndexes []uint32         `json:"non_consecutive_internal_indexes"` // Used internal indexes that are creating a gap in the derivation
-	AccountIndex                  uint32           `json:"account_index"`                    // Account index
 	Metadata                      string           `json:"metadata"`                         // Additional info, unspecified
 }
 

--- a/pkg/keystore/wdstate.go
+++ b/pkg/keystore/wdstate.go
@@ -81,7 +81,7 @@ func ParseKeychainState(b64pref string) (WDKeychainState, error) {
 func EncodeKeychainState(state WDKeychainState) (string, error) {
 	var buffer bytes.Buffer
 
-	var version uint32 = 0
+	var version uint32
 	err := binary.Write(&buffer, binary.LittleEndian, version)
 	if err != nil {
 		return "", err

--- a/pkg/keystore/wdstate_test.go
+++ b/pkg/keystore/wdstate_test.go
@@ -57,6 +57,5 @@ func TestWDState(t *testing.T) {
 		if !reflect.DeepEqual(state, test.state) {
 			t.Fatal("unexpected result for parse", state)
 		}
-
 	}
 }


### PR DESCRIPTION
**Notable changes:**
* Upgrade to Go 1.16
* Fix struct alignment errors to make it more memory-efficient.

⚠️ Please upgrade go and golangci-lint locally.
```
$ brew upgrade go
$ brew upgrade golangci-lint 
```