### PR TITLE
Bip49

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ WORKDIR /tmp/
 RUN tar xvzf protobuf.tar.gz
 WORKDIR /tmp/protobuf-$PROTOBUF_VERSION
 RUN mkdir /tmp/protobuf
-RUN ./autogen.sh && ./configure --prefix=/tmp/protobuf && make && make install
+RUN ./autogen.sh && ./configure --prefix=/tmp/protobuf && make -j8 && make install
 RUN ln -s /tmp/protobuf/bin/protoc /usr/local/bin/protoc
 
 # Install mage

--- a/pkg/keystore/wd.go
+++ b/pkg/keystore/wd.go
@@ -247,17 +247,23 @@ func keychainInfoToWalletType(keychainInfo KeychainInfo) (string, error) {
 	case chaincfg.LitecoinMainnet:
 		return "litecoin", nil
 	case chaincfg.BitcoinMainnet:
-		// BIP49 is not supported by vault
-
-		if keychainInfo.Scheme == BIP44 {
+		switch keychainInfo.Scheme {
+		case BIP44:
 			return "bitcoin", nil
-		} else if keychainInfo.Scheme == BIP84 {
+		case BIP49:
+			// XXX: bip49 is not supported in vault, this value will never be
+			// seen in redis, but it is useful for lama test suite
+			return "bitcoin_segwit", nil
+		case BIP84:
 			return "bitcoin_native_segwit", nil
 		}
 	case chaincfg.BitcoinTestnet3:
-		if keychainInfo.Scheme == BIP44 {
+		switch keychainInfo.Scheme {
+		case BIP44:
 			return "bitcoin_testnet", nil
-		} else if keychainInfo.Scheme == BIP84 {
+		case BIP49:
+			return "bitcoin_testnet_segwit", nil
+		case BIP84:
 			return "bitcoin_testnet_native_segwit", nil
 		}
 	}


### PR DESCRIPTION
add a account string for bip49: "bitcoin_segwit"
It is not supported by vault, so this string will not be seen in redis. However,
lama test suite use it, so better supporting it.