### PR TITLE
add a healthcheck utility to the keychain

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,9 +1,16 @@
 name: Build and publish to ghcr.io
 
 on:
+  release:
+    types: [ published ]
+  pull_request:
+    branches:
+      - main
+      - 'release/*'
   push:
     branches:
       - main
+      - 'release/*'
 
 jobs:
   build:
@@ -30,14 +37,14 @@ jobs:
         uses: docker/login-action@v1
         with:
           registry: ghcr.io
-          username: ${{ secrets.CI_BOT_USERNAME }}
-          password: ${{ secrets.CI_BOT_TOKEN }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push
+      - name: Build and Publish
         id: docker_build
         uses: docker/build-push-action@v2
         with:
           context: .
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          push: true
+          push: ${{ github.event_name == 'push' || github.event_name == 'release' }}

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,5 +1,12 @@
 name: Build and Test
-on: [push]
+on:
+  pull_request:
+    branches:
+      - main
+      - 'release/*'
+  push:
+    branches:
+      - '*'
 jobs:
   build:
     name: Go CI

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,5 +1,12 @@
 name: Integration tests
-on: [push]
+on:
+  pull_request:
+    branches:
+      - main
+      - 'release/*'
+  push:
+    branches:
+      - '*'
 jobs:
   build:
     name: Go CI

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ RUN mage -v build
 FROM alpine
 
 RUN wget -O /bin/grpc_health_probe \
-    https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v0.4.5/grpc_health_probe-linux-386 /bin/grpc_health_probe \
+    https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v0.4.5/grpc_health_probe-linux-386 \
     && chmod +x /bin/grpc_health_probe
 COPY --from=builder /app/server /app/server
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,9 @@ RUN mage -v build
 # Start fresh from a smaller image
 FROM alpine
 
+RUN wget -O /bin/grpc_health_probe \
+    https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v0.4.5/grpc_health_probe-linux-386 /bin/grpc_health_probe \
+    && chmod +x /bin/grpc_health_probe
 COPY --from=builder /app/server /app/server
 
 ENV GRPC_GO_LOG_SEVERITY_LEVEL info


### PR DESCRIPTION
https://kubernetes.io/blog/2018/10/01/health-checking-grpc-servers-on-kubernetes/

Check the above link for extended documentation. Adding a binary in the container
seems to be the state-of-the art way to get a healthcheck on a GRPC server.